### PR TITLE
Check webapp, supabase, and deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/package.json /app/package.json
 COPY --from=builder /app/entrypoint.sh /app/entrypoint.sh
+COPY --from=builder /app/drizzle.config.ts /app/drizzle.config.ts
+COPY --from=builder /app/tsconfig.json /app/tsconfig.json
+COPY --from=builder /app/shared /app/shared
 RUN chmod +x /app/entrypoint.sh
 # Expose port
 EXPOSE 5000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,18 @@ set -e
 # Run database migrations if configured to use DB
 if [ "${USE_DB}" = "true" ] && [ -n "${DATABASE_URL}" ]; then
   echo "Running database migrations (drizzle-kit push)..."
+  # Ensure sslmode=require is present for Supabase/managed Postgres
+  if echo "$DATABASE_URL" | grep -q "?"; then
+    export DATABASE_URL_WITH_SSL="${DATABASE_URL}&sslmode=require"
+  else
+    export DATABASE_URL_WITH_SSL="${DATABASE_URL}?sslmode=require"
+  fi
+
+  # Try to enable pgcrypto extension for gen_random_uuid()
+  node -e "const { Client } = require('pg');(async()=>{const c=new Client({connectionString:process.env.DATABASE_URL_WITH_SSL,ssl:{rejectUnauthorized:false}});try{await c.connect();await c.query('create extension if not exists pgcrypto');console.log('pgcrypto enabled or already present');}catch(e){console.error('pgcrypto enable skipped:', e.message);}finally{try{await c.end();}catch(e){}}})()" || true
+
   # Allow continue if already up-to-date
-  npm run db:push || true
+  DATABASE_URL=\"$DATABASE_URL_WITH_SSL\" npm run db:push || true
 else
   echo "Skipping migrations (USE_DB!=true or DATABASE_URL missing)"
 fi

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,7 +21,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
     try {
       const { Client } = await import("pg");
-      const client = new Client({ connectionString: process.env.DATABASE_URL });
+      const client = new Client({
+        connectionString: process.env.DATABASE_URL,
+        ssl: process.env.DATABASE_SSL === "true" ? { rejectUnauthorized: false } : undefined,
+      });
       await client.connect();
       const result = await client.query("SELECT 1 as ok");
       await client.end();


### PR DESCRIPTION
Make the application Render-ready for Supabase deployment by enabling automatic pgcrypto extension, running Drizzle migrations, and ensuring SSL connectivity.

The changes ensure the Docker image contains necessary Drizzle configuration for migrations to run at runtime on Render, automatically enables the `pgcrypto` extension required by Drizzle's `gen_random_uuid()`, and correctly configures SSL for the database connection, including the `/api/system/db-check` endpoint. This streamlines deployment to Render with a Supabase Postgres backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-7293d151-3425-469d-8e33-3483e96c9eba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7293d151-3425-469d-8e33-3483e96c9eba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make the app Render-ready with Supabase by auto-running Drizzle migrations, enabling pgcrypto, and supporting SSL DB connections. This stabilizes deployments and fixes the /api/system/db-check against managed Postgres.

- New Features
  - Auto-run Drizzle migrations at startup with sslmode=require.
  - Enable pgcrypto for gen_random_uuid() if missing.
  - Add optional SSL for the server DB client via DATABASE_SSL=true; the /api/system/db-check uses it.
  - Include Drizzle config and shared code in the Docker image for runtime migrations.

- Migration
  - Set USE_DB=true and DATABASE_URL in Render.
  - For Supabase or other managed Postgres, set DATABASE_SSL=true.

<!-- End of auto-generated description by cubic. -->

